### PR TITLE
Fix env vars

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,3 +42,4 @@
 *.example
 *test.py
 meetup_queries.gql
+jsonwebtoken_test/


### PR DESCRIPTION
Prefer base64 encode/decode vs. fixing newlines + 64 char lines. Cast jwt expiration env var as int. Exclude node jwt files from container