### PR TITLE
Add integration test suite with TestClient and pytest markers

### DIFF
--- a/backlog/tasks/task-005 - Add-integration-test-suite-with-server-lifecycle-management.md
+++ b/backlog/tasks/task-005 - Add-integration-test-suite-with-server-lifecycle-management.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-005
 title: Add integration test suite with server lifecycle management
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-02-26 18:06'
+updated_date: '2026-02-26 18:23'
 labels:
   - testing
 dependencies: []
@@ -23,9 +24,15 @@ Create integration test suite that tests component interactions (FastAPI routes 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 pytest marker `integration` registered in pyproject.toml
-- [ ] #2 test_smoke.py refactored to use integration marker and TestClient (no manual server needed)
-- [ ] #3 Integration tests can run against a real or test database
-- [ ] #4 task test:integration in taskfile handles server start/stop automatically
-- [ ] #5 Server health check wait loop before test execution
+- [x] #1 pytest marker `integration` registered in pyproject.toml
+- [x] #2 test_smoke.py refactored to use integration marker and TestClient (no manual server needed)
+- [x] #3 Integration tests can run against a real or test database
+- [x] #4 task test:integration in taskfile handles server start/stop automatically
+- [x] #5 Server health check wait loop before test execution
 <!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Changes\n\n### pyproject.toml\n- Add `[tool.pytest.ini_options]` section with `markers` for `unit`, `integration`, `e2e`, and `property` test categories\n\n### tests/conftest.py\n- Add `_load_env_file()` helper to load `app/.env` when present (respects existing env vars)\n- Add `integration_client` fixture that provides a FastAPI `TestClient`, skipping gracefully when env vars or DB are unavailable\n\n### tests/test_smoke.py\n- Replace `requests`-based smoke test with `TestClient`-based integration test\n- Add `@pytest.mark.integration` marker\n- Split into `TestHealthz` class with `test_status_code` and `test_response_body` methods\n- No longer requires a running server (uses in-process TestClient)\n\n### Pre-existing (no changes needed)\n- `taskfiles/pytest.yml` already implements `test:integration` with server start/defer-stop/wait lifecycle\n- `taskfile.yml` already delegates `test:integration` to `pytest:test:integration`"
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ test = [
     "pytest-xdist<4.0.0,>=3.6.1",
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "unit: unit tests (no external dependencies)",
+    "integration: integration tests (component interactions, TestClient)",
+    "e2e: end-to-end tests (requires running server)",
+    "property: property-based tests (Hypothesis)",
+]
+
 [tool.deptry]
 # DEP003: transitive deps
 ignore = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,23 +23,6 @@ pony.orm.Database.generate_mapping = lambda *a, **kw: None
 groups_csv_path = app_path / "groups.csv"
 
 
-def _load_env_file():
-    """Load app/.env if it exists and env vars aren't already set."""
-    env_file = root_path / "app" / ".env"
-    if not env_file.exists():
-        return False
-    for line in env_file.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        value = value.strip().strip('"').strip("'")
-        if key and key not in os.environ:
-            os.environ[key] = value
-    return True
-
-
 @pytest.fixture
 def groups_csv_fixture():
     return str(groups_csv_path)
@@ -90,7 +73,6 @@ def integration_client():
     Requires app/.env or equivalent environment variables.
     Skips if the app cannot be imported due to missing configuration.
     """
-    _load_env_file()
     try:
         from app.main import app
     except Exception as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,23 @@ pony.orm.Database.generate_mapping = lambda *a, **kw: None
 groups_csv_path = app_path / "groups.csv"
 
 
+def _load_env_file():
+    """Load app/.env if it exists and env vars aren't already set."""
+    env_file = root_path / "app" / ".env"
+    if not env_file.exists():
+        return False
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+    return True
+
+
 @pytest.fixture
 def groups_csv_fixture():
     return str(groups_csv_path)
@@ -64,3 +81,21 @@ def mock_env():
     }
     with patch("decouple.config", side_effect=lambda key, **kwargs: defaults.get(key, kwargs.get("default", ""))):
         yield defaults
+
+
+@pytest.fixture
+def integration_client():
+    """TestClient for integration tests against the FastAPI app.
+
+    Requires app/.env or equivalent environment variables.
+    Skips if the app cannot be imported due to missing configuration.
+    """
+    _load_env_file()
+    try:
+        from app.main import app
+    except Exception as exc:
+        pytest.skip(f"Cannot import app (missing env vars or DB): {exc}")
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        yield client

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,18 +1,12 @@
 import pytest
-import requests
-from decouple import config
-
-base_url = config('URL', default='http://localhost')
-if base_url == 'http://localhost':
-    port = config('PORT', default='3000')
-    url = f"{base_url}:{port}"
-else:
-    url = base_url
-
-response = requests.get(f"{url}/healthz")
 
 
 @pytest.mark.integration
-def test_healthz_endpoint():
-    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
-    assert response.text == '{"status":"ok"}', f"Unexpected response content: {response.text}"
+class TestHealthz:
+    def test_status_code(self, integration_client):
+        response = integration_client.get("/healthz")
+        assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
+
+    def test_response_body(self, integration_client):
+        response = integration_client.get("/healthz")
+        assert response.json() == {"status": "ok"}, f"Unexpected response content: {response.text}"


### PR DESCRIPTION
## Summary

Add integration test infrastructure with pytest markers and TestClient-based integration tests. Registered pytest markers (unit, integration, e2e, property) in pyproject.toml to categorize tests. Added `integration_client` fixture that provides FastAPI TestClient, automatically loads app/.env when present, and skips gracefully if environment variables are unavailable. Refactored test_smoke.py to use TestClient instead of making HTTP requests to a running server, eliminating the need for manual server management during testing.

## Test plan

- Integration tests can now run in isolation without a running server
- When run via `task test:integration`, the taskfile manages server lifecycle automatically
- Tests skip gracefully in environments without proper configuration (e.g., CI without secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)